### PR TITLE
Single entry point

### DIFF
--- a/piecewise/piecewise/__main__.py
+++ b/piecewise/piecewise/__main__.py
@@ -1,0 +1,110 @@
+import argparse
+
+import piecewise.config
+import piecewise.ingest
+import piecewise.aggregate
+
+def refine(config, args):
+    modified_aggregations = []
+    for agg in config.aggregations:
+        if args.only_compute is not None and not agg.name in args.only_compute:
+            continue
+
+        modified_bins = []
+        for b in agg.bins:
+            if args.only_bins is not None and not b.label in args.only_bins:
+                continue
+            modified_bins.append(b)
+
+        modified_stats = []
+        for s in agg.statistics:
+            if args.only_statistics is not None and not s.label in args.only_statistics:
+                continue
+            modified_stats.append(s)
+
+        modified_agg = piecewise.aggregate.Aggregation(
+                name = agg.name,
+                statistics_table_name = agg.statistics_table_name,
+                bins = modified_bins,
+                statistics = modified_stats)
+        modified_aggregations.append(modified_agg)
+    return piecewise.aggregate.Aggregator(
+            database_uri = config.database_uri,
+            cache_table_name = config.cache_table_name,
+            filters = config.filters,
+            aggregations = modified_aggregations)
+
+def do_ingest(args):
+    config = piecewise.config.read_system_config()
+    config = refine(config, args)
+    if not args.debug:
+        piecewise.ingest.ingest(config)
+    else:
+        print "Displaying bigquery SQL instead of performing query"
+        print config.ingest_bigquery_query()
+
+def do_aggregate(args):
+    config = piecewise.config.read_system_config()
+    config = refine(config, args)
+    if not args.debug:
+        piecewise.aggregate.aggregate(config)
+    else:
+        print "Displaying Postgres SQL instead of performing query"
+        piecewise.aggregate.aggregate(config, args.debug)
+
+def do_reset(args):
+    print 'Reset'
+
+def do_load(args):
+    do_ingest(args)
+    do_aggregate(args)
+
+def do_display_config(args):
+    config = piecewise.config.read_system_config()
+    config = refine(config, args)
+    print 'Postgres connection: {}'.format(config.database_uri)
+    print 'Results cache table: {}'.format(config.cache_table_name)
+    print 'Filters:'
+    for filt in config.filters:
+        print '\t{}'.format(filt)
+    print
+    print 'Aggregations:'
+    for agg in config.aggregations:
+        print '\t{}'.format(agg.name)
+        print '\t* Bin dimensions'
+        for b in agg.bins:
+            print '\t\t{}: {}'.format(b.label, b)
+        print '\t* Aggregate statistics'
+        for s in agg.statistics:
+            print '\t\t{}'.format(s)
+
+def add_ingest_args(parser):
+    pass 
+
+def add_aggregate_args(parser):
+    pass
+
+def split_string(string):
+    return string.split(',')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog="piecewise", description="Download and aggregate m-lab internet performance data")
+    parser.add_argument("--debug", action='store_true', help = 'Display rather than execute queries')
+    parser.add_argument("--only-compute", type=split_string, help='Use only the named aggregations for this run')
+    parser.add_argument("--only-bins", type=split_string, help='Use only the named bin dimensions for this run')
+    parser.add_argument("--only-statistics", type=split_string, help='Use only the named statistics for this run')
+    subparsers = parser.add_subparsers(help="Operation")
+    ingest_parser = subparsers.add_parser('ingest', help='Pull data from BigQuery into postgres database')
+    add_ingest_args(ingest_parser)
+    ingest_parser.set_defaults(func=do_ingest)
+    aggregate_parser = subparsers.add_parser('aggregate', help='Compute statistics from ingested internet performance data')
+    add_aggregate_args(aggregate_parser)
+    aggregate_parser.set_defaults(func=do_aggregate)
+    display_config_parser = subparsers.add_parser("display-config", help='Display parsed configuration')
+    display_config_parser.set_defaults(func=do_display_config)
+    load_parser = subparsers.add_parser('load', help='Ingest and aggregate data in one run')
+    add_ingest_args(load_parser)
+    add_aggregate_args(load_parser)
+    load_parser.set_defaults(func=do_load)
+    args = parser.parse_args()
+    args.func(args)

--- a/piecewise/piecewise/aggregate.py
+++ b/piecewise/piecewise/aggregate.py
@@ -70,7 +70,7 @@ class Aggregation(object):
                 *list(chain(bin_columns, stat_columns)),
                 keep_existing = True)
 
-    def query(self, engine, metadata, bins, filters, statistics):
+    def selection(self, engine, metadata, bins, filters, statistics):
         table = self.make_table(metadata)
 
         bin_keys = []
@@ -84,6 +84,11 @@ class Aggregation(object):
                 selection = b.filter_query_to_report(selection, table, filters[b.label])
         for s in statistics:
             selection = s.build_query_to_report(selection, table)
+
+        return selection
+
+    def query(self, engine, metadata, bins, filters, statistics):
+        selection = self.selection(engine, metadata, bins, filters, statistics)
 
         with engine.connect() as conn:
             return conn.execute(selection)

--- a/piecewise/piecewise/bigquery.py
+++ b/piecewise/piecewise/bigquery.py
@@ -11,20 +11,22 @@ PARENT_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRETS_FILE = os.path.join(PARENT_PATH,  'client_secrets.json')
 CREDENTIALS_FILE = os.path.join(PARENT_PATH, 'bigquery_credentials.dat')
 
-FLOW = flow_from_clientsecrets(SECRETS_FILE, scope='https://www.googleapis.com/auth/bigquery')
+def client():
+    FLOW = flow_from_clientsecrets(SECRETS_FILE, scope='https://www.googleapis.com/auth/bigquery')
 
-storage = Storage(CREDENTIALS_FILE)
-credentials = storage.get()
+    storage = Storage(CREDENTIALS_FILE)
+    credentials = storage.get()
 
-class FlowFlags(): 
-    noauth_local_webserver = True
-    logging_level = 'ERROR'
+    class FlowFlags(): 
+        noauth_local_webserver = True
+        logging_level = 'ERROR'
 
-if credentials is None or credentials.invalid:
-    # Run oauth2 flow with default arguments.
-    credentials = tools.run_flow(FLOW, storage, FlowFlags())
+    if credentials is None or credentials.invalid:
+        # Run oauth2 flow with default arguments.
+        credentials = tools.run_flow(FLOW, storage, FlowFlags())
 
-http = httplib2.Http()
-http = credentials.authorize(http)
+    http = httplib2.Http()
+    http = credentials.authorize(http)
 
-bigquery_service = build('bigquery', 'v2', http = http)
+    bigquery_service = build('bigquery', 'v2', http = http)
+    return bigquery_service

--- a/piecewise/piecewise/ingest.py
+++ b/piecewise/piecewise/ingest.py
@@ -1,4 +1,5 @@
-from piecewise.bigquery import bigquery_service, PROJECT_NUMBER
+import piecewise.bigquery
+import piecewise.aggregate
 from sqlalchemy import create_engine, func, text, Column, Float, Integer, MetaData, String, Table
 from sqlalchemy.sql.expression import label
 import calendar
@@ -19,15 +20,17 @@ def ingest(config):
     engine.execute(records.delete())
 
     query = config.ingest_bigquery_query()
+    bigquery_service = piecewise.bigquery.client()
 
     start_time = time.time()
     query_reference = bigquery_service.jobs().insert(
-            projectId = PROJECT_NUMBER,
+            projectId = piecewise.bigquery.PROJECT_NUMBER,
             body = make_request(query)).execute()
     jobId = query_reference['jobReference']['jobId']
 
-    check_job = bigquery_service.jobs().get(projectId = PROJECT_NUMBER, jobId = jobId)
+    check_job = bigquery_service.jobs().get(projectId = piecewise.bigquery.PROJECT_NUMBER, jobId = jobId)
     job_status = check_job.execute()
+    print 'Waiting for BigQuery, this could take several minutes.'
     while job_status['status']['state'] != 'DONE':
         print '.',
         sys.stdout.flush()
@@ -37,7 +40,7 @@ def ingest(config):
     print ''
     print 'Took %d s to complete'.format(finish_time - start_time)
 
-    query_response = bigquery_service.jobs().getQueryResults(projectId = PROJECT_NUMBER, jobId = jobId, maxResults = 10000).execute()
+    query_response = bigquery_service.jobs().getQueryResults(projectId = piecewise.bigquery.PROJECT_NUMBER, jobId = jobId, maxResults = 10000).execute()
     inserter = records.insert()
     page_count = 0
     record_count = 0
@@ -55,20 +58,12 @@ def ingest(config):
         page_token = query_response.get('pageToken')
         del query_response
         if page_token is not None:
-            query_response = bigquery_service.jobs().getQueryResults(projectId = PROJECT_NUMBER, jobId = jobId, maxResults = 1000, pageToken = page_token).execute()
+            query_response = bigquery_service.jobs().getQueryResults(projectId = piecewise.bigquery.PROJECT_NUMBER, jobId = jobId, maxResults = 1000, pageToken = page_token).execute()
         else:
             break
-
-def aggregate(config):
-    from sqlalchemy.schema import CreateTable
-    engine = create_engine(config.database_uri)
-    metadata = MetaData()
-    records = config.make_cache_table(metadata)
-    for agg in config.aggregations:
-        agg.build_aggregate_table(engine, metadata, records)
 
 if __name__ == '__main__':
     import piecewise.config
     config = piecewise.config.read_system_config()
     ingest(config)
-    aggregate(config)
+    piecewise.aggregate.aggregate(config)


### PR DESCRIPTION
I started on a grown up command line interface for piecewise.  Now instead of running different modules for different options we can finely control the behavior with command line switches.

`python -m piecewise` is the base command and will print brief help text, `python -m piecewise -h` prints full help.

There are four sub-commands:
`python -m piecewise ingest` runs ONLY the big query ingest operation (different from the piecewise.ingest module which also runs aggregation.
`python -m piecewise aggregate` runs ONLY the aggregations and assumes the full results are already ingested.
`python -m piecewise load` will perform both the ingest and aggregate operations.
`python -m piecewise display-config` will print out the parsed configuration in a slightly more human-readable format than the JSON

There are also a few global flags (respected by all subcommands) for changing the behavior a bit, intended to help with troubleshooting:
`--debug` makes piecewise print out the BigQuery and Postgres SQL
`--only-aggregate=agg1,agg2` makes piecewise ignore aggregations whose names are not in the comma-separated list for this run.
`--only-bins=bin1,bin2` makes piecewise ignore binning dimensions whose names are not in the comma-separated list for this run.
`--only-statistics=stat2,stat2` makes piecewise ignore statistics whose names are not in the comma-separated list for this run.
