### PR TITLE
Use NDT fast tables.

### DIFF
--- a/piecewise/piecewise/aggregate.py
+++ b/piecewise/piecewise/aggregate.py
@@ -187,7 +187,7 @@ class Aggregator(object):
                 before = time.gmtime(f.before)[:2]
                 valid_year_months = itertools.ifilter(lambda x: after <= x <= before, valid_year_months)
 
-        return ['plx.google:m_lab.%04d_%02d.all' % ym for ym in valid_year_months]
+        return ['plx.google:m_lab.ndt.all']
 
     def bigquery_row_to_postgres_row(self, bq_row):
         bq_row = [f['v'] for f in bq_row['f']]

--- a/seattle_example/piecewise_config.json
+++ b/seattle_example/piecewise_config.json
@@ -98,8 +98,6 @@
         { "type": "temporal", "after": "Jan 1 2014 00:00:00", "before" : "Jan 1 2050 00:00:00" },
         { "type": "bbox", "bbox": [-122.6733398438,47.3630134401,-121.9509887695,47.8076208172] },
         { "type": "raw", "query": "connection_spec.data_direction IS NOT NULL" },
-        { "type": "raw", "query": "web100_log_entry.is_last_entry == true" },
-        { "type": "raw", "query": "project == 0" },
         { "type": "raw", "query": "(web100_log_entry.snap.HCThruOctetsAcked >= 8192 OR web100_log_entry.snap.HCThruOctetsReceived >= 8192)" },
         { "type": "raw", "query": "(web100_log_entry.snap.State == 1 OR (web100_log_entry.snap.State >= 5 AND web100_log_entry.snap.State <= 11))" },
         { "type": "raw", "query": "((web100_log_entry.snap.SndLimTimeRwin + web100_log_entry.snap.SndLimTimeCwnd + web100_log_entry.snap.SndLimTimeSnd) >= 9000000 OR web100_log_entry.snap.Duration >= 9000000)" },


### PR DESCRIPTION
This PR should convert piecewise to use the NDT "fast" BigQuery table, instead of the old monthly, slow ones.  There is still some code in place that figures out which monthly tables to use that this change set makes unnecessary.  We'll ultimately want to clean all that old code out of the codebase, but for the moment there is no harm in leaving in there.
