### PR TITLE
Use different values to create the bigquery_key field

### DIFF
--- a/piecewise/piecewise/aggregate.py
+++ b/piecewise/piecewise/aggregate.py
@@ -157,7 +157,7 @@ class Aggregator(object):
                 "8 * web100_log_entry.snap.HCThruOctetsAcked AS download_octets",
                 "web100_log_entry.snap.Duration AS upload_time",
                 "8 * web100_log_entry.snap.HCThruOctetsReceived AS upload_octets",
-                "CONCAT(String(web100_log_entry.snap.Duration), String(web100_log_entry.snap.CountRTT), String(web100_log_entry.snap.SegsIn), String(web100_log_entry.snap.SegsOut)) AS bigquery_key",
+                "CONCAT(String(web100_log_entry.snap.StartTimeStamp % 1000000), String(web100_log_entry.snap.LocalAddress)) AS bigquery_key",
                 "test_id"
         ]
 


### PR DESCRIPTION
The Web100 data from which we were construction the compound bigquery_key field before turned out to not match the data that clients have/receive after an NDT test is run, so there was not usable as a way of correlating M-Lab test results with the test results in the piecewise "extra_data" table.  This PR changes the underlying values on which the bigquery_key field is derived.  The NDT client should be able to recreate this same key, and the values should be unique enough for our purposes.
