### PR TITLE
Update to support all stats in master

### DIFF
--- a/seattle_example/piecewise_config.json
+++ b/seattle_example/piecewise_config.json
@@ -41,9 +41,13 @@
             { "type" : "AverageRTT" },
             { "type" : "MedianRTT" },
             { "type" : "DownloadCount" },
+            { "type" : "DownloadMin" },
+            { "type" : "DownloadMax" },
             { "type" : "AverageDownload" },
             { "type" : "MedianDownload" },
             { "type" : "UploadCount" },
+            { "type" : "UploadMin" },
+            { "type" : "UploadMax" },
             { "type" : "AverageUpload" },
             { "type" : "MedianUpload" }
         ]
@@ -87,9 +91,13 @@
             { "type" : "AverageRTT" },
             { "type" : "MedianRTT" },
             { "type" : "DownloadCount" },
+            { "type" : "DownloadMin" },
+            { "type" : "DownloadMax" },
             { "type" : "AverageDownload" },
             { "type" : "MedianDownload" },
             { "type" : "UploadCount" },
+            { "type" : "UploadMin" },
+            { "type" : "UploadMax" },
             { "type" : "AverageUpload" },
             { "type" : "MedianUpload" }
         ]

--- a/seattle_example/piecewise_config.json
+++ b/seattle_example/piecewise_config.json
@@ -3,55 +3,6 @@
     "database_uri" : "postgresql+psycopg2://postgres:@/piecewise",
     "cache_table_name": "results",
     "aggregations": [{
-        "name": "by_council_district",
-        "statistics_table_name": "district_statistics",
-        "bins": [
-            { "type" : "spatial_join", "table" : "seattle_council_districts", "geometry_column" : "wkb_geometry", "key" : "district", "join_custom_data" : true },
-            { "type" : "time_slices", "resolution" : "month" },
-            { "type" : "isp_bins", "maxmind_table" : "maxmind", 
-                "rewrites" : {
-		    "aerioconnect": ["aerioconnect"],
-		    "at&t": ["at&t services", "at&t mobility llc", "wayport"],
-                    "cablevision": ["cablevision systems", "csc holdings", "cablevision infrastructure", "cablevision corporate", "optimum online", "optimum wifi", "optimum network"],
-		    "cascasde link": ["cascasdelink inc"],
-                    "centurylink": ["qwest", "embarq", "centurylink", "centurytel"],
-		    "cequint": ["cequint"],
-		    "comcast": ["comcast cable communications"],
-		    "cox communications": ["cox communications inc."],
-		    "elauwit networks": ["elauwit"],
-		    "frontier": ["frontier communications of america"],
-		    "hughes": ["hughes network systems"],
-                    "level3": ["level 3 communications", "glbx"],
-		    "MDU Communications": ["mdu communications (usa)"],
-		    "northland cable": ["northland cable television inc."],
-		    "rainier connect": ["rainier connect"],
-		    "sprint": ["sprint"],
-		    "t-mobile": ["t-mobile usa"],
-                    "twc": ["time warner"],
-		    "visionary communications": ["visionary communications"], 
-		    "verizon": ["cellco partnership dba verizon wireless"],
-		    "wave": ["wave broadband", "broadstripe", "condointernet.net"],
-		    "windstream": ["windstream communications inc"],
-		    "wolfe": ["wolfenet"],
-		    "whidbey internet services": ["whidbey internet services"],
-		    "xo communciations": ["xo communications"]
-                } }
-        ],
-        "statistics": [
-            { "type" : "AverageRTT" },
-            { "type" : "MedianRTT" },
-            { "type" : "DownloadCount" },
-            { "type" : "DownloadMin" },
-            { "type" : "DownloadMax" },
-            { "type" : "AverageDownload" },
-            { "type" : "MedianDownload" },
-            { "type" : "UploadCount" },
-            { "type" : "UploadMin" },
-            { "type" : "UploadMax" },
-            { "type" : "AverageUpload" },
-            { "type" : "MedianUpload" }
-        ]
-    }, {
         "name": "by_census_block",
         "statistics_table_name": "block_statistics",
         "bins": [

--- a/system_tasks.yml
+++ b/system_tasks.yml
@@ -29,7 +29,7 @@
 - name: Fetch piecewise
   git: repo=https://github.com/opentechinstitute/piecewise.git
        dest=/opt/piecewise.git/
-       version=master
+       version=8-16-16_updates
 
 - name: Deploy piecewise
   file: src=/opt/piecewise.git/{{ item.src }} dest=/opt/{{ item.dest }} state=link

--- a/system_tasks.yml
+++ b/system_tasks.yml
@@ -29,7 +29,7 @@
 - name: Fetch piecewise
   git: repo=https://github.com/opentechinstitute/piecewise.git
        dest=/opt/piecewise.git/
-       version=8-16-16_updates
+       version=master
 
 - name: Deploy piecewise
   file: src=/opt/piecewise.git/{{ item.src }} dest=/opt/{{ item.dest }} state=link


### PR DESCRIPTION
Master branch was throwing a couple errors when attempting to provision/deploy.
- DownloadMin, Max and UploadMin, Max were not included in the aggregation bins and therefore caused an error when aggregating
- Removed unused aggregation "by_council_district" since it causes aggregate.py to error out when running

This commit is confirmed to build a working, default installation, running on Ubuntu 16.04
