### PR TITLE
Add ssl support

### DIFF
--- a/conf/etc/nginx/sites-available/default
+++ b/conf/etc/nginx/sites-available/default
@@ -17,15 +17,21 @@
 # Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
 ##
 
+# Redirect to HTTPS
 server {
 	listen 80 default_server;
-	listen [::]:80 default_server ipv6only=on;
+	listen [::]:80 default_server;
+	server_name 168.62.227.64;
+	return 301 https://$server_name$request_uri;
+}
+# HTTPS server
+#
+server {
+	listen 443;
+	server_name localhost ipv6only=on;
 
 	root /opt/piecewise_web;
 	index index.html index.htm;
-
-	# Make site accessible from http://localhost/
-	server_name localhost;
 
     location = /stats { rewrite ^ /stats/; }
     location /stats  { try_files $uri @stats; }
@@ -63,6 +69,65 @@ server {
 		auth_basic_user_file /opt/piecewise.git/htpasswd;
 	}
 
+	ssl on;
+	ssl_certificate /etc/ssl/localcerts/localcert.pem;
+	ssl_certificate_key /etc/ssl/localcerts/localcert.key;
+
+	ssl_session_timeout 5m;
+
+	ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+	ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
+	ssl_prefer_server_ciphers on;
+
+}
+
+# Config for http piecewise server. Note that geolocation in Chrome won't work without HTTPS
+#server {
+#	listen 80 default_server;
+#	listen [::]:80 default_server ipv6only=on;
+#
+#	root /opt/piecewise_web;
+#	index index.html index.htm;
+#
+#	# Make site accessible from http://localhost/
+#	server_name localhost;
+#
+#    location = /stats { rewrite ^ /stats/; }
+#    location /stats  { try_files $uri @stats; }
+#    location @stats {
+#      include uwsgi_params;
+#      uwsgi_param SCRIPT_NAME /stats;
+#      uwsgi_modifier1 30;
+#      uwsgi_pass unix:///tmp/uwsgi-piecewise.sock;
+#    }
+#
+#    location = /collector { rewrite ^ /collector/; }
+#    location /collector  { try_files $uri @collector; }
+#    location @collector {
+#      include uwsgi_params;
+#      uwsgi_param SCRIPT_NAME /collector;
+#      uwsgi_modifier1 30;
+#      uwsgi_pass unix:///tmp/uwsgi-collector.sock;
+#    }
+#	location /collector/retrieve {
+#		try_files $uri @collector;
+#		auth_basic "Custom Data";
+#		auth_basic_user_file /opt/piecewise.git/htpasswd;
+#	}
+#
+#	location / {
+#		# First attempt to serve request as file, then
+#		# as directory, then fall back to displaying a 404.
+#		try_files $uri $uri/ =404;
+#		# Uncomment to enable naxsi on this location
+#		# include /etc/nginx/naxsi.rules
+#	}
+#
+#	location /admin {
+#		auth_basic "Custom Data Admin";
+#		auth_basic_user_file /opt/piecewise.git/htpasswd;
+#	}
+#
 	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
 	#location /RequestDenied {
 	#	proxy_pass http://127.0.0.1:8080;    
@@ -97,7 +162,7 @@ server {
 	#location ~ /\.ht {
 	#	deny all;
 	#}
-}
+#}
 
 
 # another virtual host using mix of IP-, name-, and port-based configuration

--- a/conf/etc/nginx/sites-available/default
+++ b/conf/etc/nginx/sites-available/default
@@ -28,7 +28,7 @@ server {
 #
 server {
 	listen 443;
-	server_name localhost ipv6only=on;
+	server_name localhost;
 
 	root /opt/piecewise_web;
 	index index.html index.htm;
@@ -36,19 +36,19 @@ server {
     location = /stats { rewrite ^ /stats/; }
     location /stats  { try_files $uri @stats; }
     location @stats {
-      include uwsgi_params;
-      uwsgi_param SCRIPT_NAME /stats;
-      uwsgi_modifier1 30;
-      uwsgi_pass unix:///tmp/uwsgi-piecewise.sock;
+    	include uwsgi_params;
+    	uwsgi_param SCRIPT_NAME /stats;
+    	uwsgi_modifier1 30;
+		uwsgi_pass unix:///tmp/uwsgi-piecewise.sock;
     }
 
     location = /collector { rewrite ^ /collector/; }
     location /collector  { try_files $uri @collector; }
     location @collector {
-      include uwsgi_params;
-      uwsgi_param SCRIPT_NAME /collector;
-      uwsgi_modifier1 30;
-      uwsgi_pass unix:///tmp/uwsgi-collector.sock;
+		include uwsgi_params;
+    	uwsgi_param SCRIPT_NAME /collector;
+    	uwsgi_modifier1 30;
+    	uwsgi_pass unix:///tmp/uwsgi-collector.sock;
     }
 	location /collector/retrieve {
 		try_files $uri @collector;
@@ -80,126 +80,3 @@ server {
 	ssl_prefer_server_ciphers on;
 
 }
-
-# Config for http piecewise server. Note that geolocation in Chrome won't work without HTTPS
-#server {
-#	listen 80 default_server;
-#	listen [::]:80 default_server ipv6only=on;
-#
-#	root /opt/piecewise_web;
-#	index index.html index.htm;
-#
-#	# Make site accessible from http://localhost/
-#	server_name localhost;
-#
-#    location = /stats { rewrite ^ /stats/; }
-#    location /stats  { try_files $uri @stats; }
-#    location @stats {
-#      include uwsgi_params;
-#      uwsgi_param SCRIPT_NAME /stats;
-#      uwsgi_modifier1 30;
-#      uwsgi_pass unix:///tmp/uwsgi-piecewise.sock;
-#    }
-#
-#    location = /collector { rewrite ^ /collector/; }
-#    location /collector  { try_files $uri @collector; }
-#    location @collector {
-#      include uwsgi_params;
-#      uwsgi_param SCRIPT_NAME /collector;
-#      uwsgi_modifier1 30;
-#      uwsgi_pass unix:///tmp/uwsgi-collector.sock;
-#    }
-#	location /collector/retrieve {
-#		try_files $uri @collector;
-#		auth_basic "Custom Data";
-#		auth_basic_user_file /opt/piecewise.git/htpasswd;
-#	}
-#
-#	location / {
-#		# First attempt to serve request as file, then
-#		# as directory, then fall back to displaying a 404.
-#		try_files $uri $uri/ =404;
-#		# Uncomment to enable naxsi on this location
-#		# include /etc/nginx/naxsi.rules
-#	}
-#
-#	location /admin {
-#		auth_basic "Custom Data Admin";
-#		auth_basic_user_file /opt/piecewise.git/htpasswd;
-#	}
-#
-	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
-	#location /RequestDenied {
-	#	proxy_pass http://127.0.0.1:8080;    
-	#}
-
-	#error_page 404 /404.html;
-
-	# redirect server error pages to the static page /50x.html
-	#
-	#error_page 500 502 503 504 /50x.html;
-	#location = /50x.html {
-	#	root /usr/share/nginx/html;
-	#}
-
-	# pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-	#
-	#location ~ \.php$ {
-	#	fastcgi_split_path_info ^(.+\.php)(/.+)$;
-	#	# NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
-	#
-	#	# With php5-cgi alone:
-	#	fastcgi_pass 127.0.0.1:9000;
-	#	# With php5-fpm:
-	#	fastcgi_pass unix:/var/run/php5-fpm.sock;
-	#	fastcgi_index index.php;
-	#	include fastcgi_params;
-	#}
-
-	# deny access to .htaccess files, if Apache's document root
-	# concurs with nginx's one
-	#
-	#location ~ /\.ht {
-	#	deny all;
-	#}
-#}
-
-
-# another virtual host using mix of IP-, name-, and port-based configuration
-#
-#server {
-#	listen 8000;
-#	listen somename:8080;
-#	server_name somename alias another.alias;
-#	root html;
-#	index index.html index.htm;
-#
-#	location / {
-#		try_files $uri $uri/ =404;
-#	}
-#}
-
-
-# HTTPS server
-#
-#server {
-#	listen 443;
-#	server_name localhost;
-#
-#	root html;
-#	index index.html index.htm;
-#
-#	ssl on;
-#	ssl_certificate cert.pem;
-#	ssl_certificate_key cert.key;
-#
-#	ssl_session_timeout 5m;
-#
-#	ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-#	ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
-#	ssl_prefer_server_ciphers on;
-#
-#	location / {
-#		try_files $uri $uri/ =404;
-#	}
-#}

--- a/conf/etc/nginx/sites-available/default
+++ b/conf/etc/nginx/sites-available/default
@@ -21,7 +21,7 @@
 server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
-	server_name 168.62.227.64;
+	server_name localhost;
 	return 301 https://$server_name$request_uri;
 }
 # HTTPS server

--- a/conf/etc/nginx/sites-available/default
+++ b/conf/etc/nginx/sites-available/default
@@ -33,23 +33,23 @@ server {
 	root /opt/piecewise_web;
 	index index.html index.htm;
 
-    location = /stats { rewrite ^ /stats/; }
-    location /stats  { try_files $uri @stats; }
-    location @stats {
-    	include uwsgi_params;
-    	uwsgi_param SCRIPT_NAME /stats;
-    	uwsgi_modifier1 30;
-		uwsgi_pass unix:///tmp/uwsgi-piecewise.sock;
-    }
-
-    location = /collector { rewrite ^ /collector/; }
-    location /collector  { try_files $uri @collector; }
-    location @collector {
+	location = /stats { rewrite ^ /stats/; }
+	location /stats  { try_files $uri @stats; }
+	location @stats {
 		include uwsgi_params;
-    	uwsgi_param SCRIPT_NAME /collector;
-    	uwsgi_modifier1 30;
-    	uwsgi_pass unix:///tmp/uwsgi-collector.sock;
-    }
+		uwsgi_param SCRIPT_NAME /stats;
+		uwsgi_modifier1 30;
+		uwsgi_pass unix:///tmp/uwsgi-piecewise.sock;
+	}
+
+	location = /collector { rewrite ^ /collector/; }
+	location /collector  { try_files $uri @collector; }
+	location @collector {
+		include uwsgi_params;
+		uwsgi_param SCRIPT_NAME /collector;
+		uwsgi_modifier1 30;
+		uwsgi_pass unix:///tmp/uwsgi-collector.sock;
+	}
 	location /collector/retrieve {
 		try_files $uri @collector;
 		auth_basic "Custom Data";
@@ -60,6 +60,7 @@ server {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
 		try_files $uri $uri/ =404;
+
 		# Uncomment to enable naxsi on this location
 		# include /etc/nginx/naxsi.rules
 	}
@@ -78,5 +79,4 @@ server {
 	ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
 	ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
 	ssl_prefer_server_ciphers on;
-
 }

--- a/piecewise_web/index.html
+++ b/piecewise_web/index.html
@@ -7,7 +7,7 @@
 	<title>Your Map's Name</title>
 	<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no' />
 	<link href='https://api.tiles.mapbox.com/mapbox.js/v2.1.6/mapbox.css' rel='stylesheet' />
-	<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 	<link href='css/ndt_d3.css' rel='stylesheet' />
 	<link href="css/jquery-ui-slider-pips.css" rel="stylesheet" />
 	<link href='css/jquery-ui.min.css' rel='stylesheet' />

--- a/piecewise_web/index.html
+++ b/piecewise_web/index.html
@@ -212,7 +212,7 @@
 		document.getElementById('longitude').value = position.coords.longitude;
 
 		var xhr = new XMLHttpRequest(),
-		currentLocationURL = "http://nominatim.openstreetmap.org/reverse?format=json&lat=" + position.coords.latitude + "&lon=" + position.coords.longitude + "&zoom=18&addressdetails=1";
+		currentLocationURL = "https://nominatim.openstreetmap.org/reverse?format=json&lat=" + position.coords.latitude + "&lon=" + position.coords.longitude + "&zoom=18&addressdetails=1";
 
 		var currentLoc;
 		xhr.open('GET', currentLocationURL, true);
@@ -239,7 +239,7 @@
 
 	function getNdtServer () {
 		var xhr = new XMLHttpRequest(),
-			mlabNsUrl = 'http://mlab-ns.appspot.com/ndt?format=json';
+			mlabNsUrl = 'https://mlab-ns.appspot.com/ndt?format=json';
 
 		xhr.open('GET', mlabNsUrl, true);
 		xhr.send();


### PR DESCRIPTION
This PR addresses issue #93 , making SSL the default for the Piecewise web server and all resources it loads. 
**Note**:  deploying this PR will break the current NDT.js test embedded in Piecewise, as it does not support secure websockets. A future PR will address issue #92 , replacing the current test with an updated version that supports secure websockets.