### PR TITLE
Update to latest NDT and switch to SSL for test

### DIFF
--- a/ansible/update_pw_python.yml
+++ b/ansible/update_pw_python.yml
@@ -1,0 +1,20 @@
+---
+- hosts: all
+  tasks:
+      become: true
+      become_user: root
+- name: Fetch updated piecewise repo
+  git: repo=https://github.com/opentechinstitute/piecewise.git 
+       dest=/opt/piecewise.git/
+       version=update-ndt-test
+- name: Deploy updated piecewise code
+  file: src=/opt/piecewise.git/{{ item.src }} dest=/opt/{{ item.dest }} state=link
+  with_items:
+      - { src: piecewise, dest: piecewise }
+
+- name: Restart services
+  service: name={{ item }} state=restarted
+  with_items: 
+    - uwsgi
+    - nginx
+    

--- a/ansible/update_pw_web.yml
+++ b/ansible/update_pw_web.yml
@@ -1,0 +1,22 @@
+---
+- hosts: all
+  tasks:
+    - include: update_pw_web.yml
+      become: true
+      become_user: root
+- name: Fetch updated piecewise repo
+  git: repo=https://github.com/opentechinstitute/piecewise.git 
+       dest=/opt/piecewise.git/
+       version=update-ndt-test
+
+- name: Deploy updated piecewise website code
+  file: src=/opt/piecewise.git/{{ item.src }} dest=/opt/{{ item.dest }} state=link
+  with_items:
+      - { src: piecewise_web, dest: piecewise_web }
+
+- name: Restart services
+  service: name={{ item }} state=restarted
+  with_items: 
+    - uwsgi
+    - nginx
+    

--- a/conf/etc/nginx/sites-available/default
+++ b/conf/etc/nginx/sites-available/default
@@ -71,8 +71,8 @@ server {
 	}
 
 	ssl on;
-	ssl_certificate /etc/ssl/localcerts/localcert.pem;
-	ssl_certificate_key /etc/ssl/localcerts/localcert.key;
+	ssl_certificate /etc/nginx/ssl/localcert.pem;
+	ssl_certificate_key /etc/nginx/ssl/localcert.key;
 
 	ssl_session_timeout 5m;
 

--- a/piecewise_web/index.html
+++ b/piecewise_web/index.html
@@ -185,7 +185,8 @@
 <script>
 	var ndtServer,
 		ndtServerIp,
-		ndtPort = "3001",
+		ndtPort = "3010",
+		ndtProtocol = 'wss',
 		ndtPath = "/ndt_protocol",
 		ndtUpdateInterval = 1000,
 		c2sRate,
@@ -198,7 +199,7 @@
 
 	NDT_meter = new NDTmeter('#ndt-svg');
 	NDT_meter.meter.on("click", function () {
-		NDT_client = new NDTjs(ndtServer, ndtPort, ndtPath, NDT_meter, ndtUpdateInterval);
+		NDT_client = new NDTjs(ndtServer, ndtPort, ndtProtocol, ndtPath, NDT_meter, ndtUpdateInterval);
 		NDT_client.startTest();
 	});
 
@@ -239,7 +240,7 @@
 
 	function getNdtServer () {
 		var xhr = new XMLHttpRequest(),
-			mlabNsUrl = 'https://mlab-ns.appspot.com/ndt?format=json';
+			mlabNsUrl = 'https://mlab-ns.appspot.com/ndt_ssl?format=json';
 
 		xhr.open('GET', mlabNsUrl, true);
 		xhr.send();

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,7 +2,10 @@
 - hosts: all
   tasks:
     - include: system_tasks.yml
-      sudo: True
+      become: true
+      become_user: root
     - include: user_tasks.yml
     - include: seattle_example/seattle_tasks.yml
-      sudo: True
+      become: true
+      become_user: root
+      

--- a/system_tasks.yml
+++ b/system_tasks.yml
@@ -61,6 +61,12 @@
   file: path=/var/log/piecewise/ state=directory
 - name: Install convenience python modules
   pip: name=bigquery state=latest
+- name: Create Nginx ssl directory
+  file: path=/etc/nginx/ssl/ state=directory
+- name: Create self-signed SSL cert for Nginx
+  command: openssl req -new -nodes -x509 -subj "/C=US/ST=District of Columbia/L=Washington/O=IT/CN=45.79.191.25" -days 3650 -out /etc/nginx/ssl/localcert.pem -keyout /etc/nginx/ssl/localcert.key  
+- name: Enable nginx default site
+  file: src=/etc/nginx/sites-available/default dest=/etc/nginx/sites-enabled/default state=link 
 - name: Deploy configuration files
   copy: src=conf/ dest=/ owner=root group=root
 - name: Fix postgres configuration permissions
@@ -71,8 +77,9 @@
     - uwsgi
     - nginx
     - postgresql
-- name: Create postgres database
-  sudo: yes
-  sudo_user: postgres
-  postgresql_db: name=piecewise state=present
-  command: psql -U postgres -d piecewise -f /opt/piecewise/setup.sql
+    
+- postgresql_db: 
+    name: piecewise 
+    state: present
+  
+- command: psql -U postgres -d piecewise -f /opt/piecewise/setup.sql


### PR DESCRIPTION
Applied patch that updates NDTjs to support ssl only, using the [NDT version in our ndt fork]([url](https://github.com/m-lab/ndt/tree/master/HTML5-frontend).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opentechinstitute/piecewise/104)
<!-- Reviewable:end -->
