### PR TITLE
complete issue #130 - file copies/templates instead of remote repo clone

### DIFF
--- a/ansible/group_vars/all/piecewise_global_config.yml
+++ b/ansible/group_vars/all/piecewise_global_config.yml
@@ -15,7 +15,7 @@ project_name: piecewise
 
 # Information about the fork and branch to deploy.
 # Specify any valid git remote (typically a github username)
-remote: https://github.com/critzo
+remote: https://github.com/opentechinstitute
 
 # Specify any ref (eg. branch, tag, SHA) to be deployed. This ref must be
 # pushed to the remote git_repo before it can be deployed.
@@ -24,7 +24,7 @@ piecewise_commit: master
 git_repo: "{{ remote }}/{{ project_name }}.git"
 
 # BigQuery Project Number or Project Name
-bigquery_project_num: 581276032543
+bigquery_project_num: 
 
 # Your Postgres database name and user can be customized if necessary.  
 database_name: piecewise
@@ -40,7 +40,7 @@ database_user_group: postgres
 #
 # For production installs we usually use the server's fqdn once we have it configured
 # in DNS.  
-site_fqdn: "104.197.237.109"
+site_fqdn: <IP or domain name>
 
 # The variables below will be used to generate SSL certificates. When deploying to 
 # development hosts, the country, state and city are used by open SSL to generate a 
@@ -51,11 +51,11 @@ site_fqdn: "104.197.237.109"
 # When deploying to a production host. The site_contact and the site_fqdn variables are 
 # used by EFF's certbot tool to automate the request for valid SSL certificates from 
 # the LetsEncrypt CA.
-site_contact: critzo@opentechinstitute.org
-site_country: US
-site_state: District of Columbia
-site_city: Washington
-site_ou: Open Technology Institute
+site_contact: <email@your.org.com>
+site_country: <two letter county>
+site_state: <name of your state>
+site_city: <name of your city>
+site_ou: <name of your organization>
 
 # Path for self-signed certificates to be used in development deployments
 self_signed_ssl_cert_path: /etc/ssl/certs/selfsigned.{{ site_fqdn }}.cert
@@ -332,8 +332,7 @@ rtt_result_label: "Minimum Round Trip Time:"
 rtt_result_unit: "ms"
 thank_you_heading: "Thank you!"
 thank_you_message: >
-  Your test results will be combined with others and will appear on the map 
-  at the end of the month.
+  Your test results will be combined with others and will appear on the map soon.
 
 # 'next_action_' variables define the action items present to the user after they run the test.
 next_action_message: "What do you want to do next?"

--- a/ansible/playbooks/all_hosts_tasks.yml
+++ b/ansible/playbooks/all_hosts_tasks.yml
@@ -8,12 +8,6 @@
 - name: Create an alias for telescope in the deploy users' profile
   shell: echo 'alias telescope="PYTHONPATH=/opt/telescope python /opt/telescope/main.py"' >> .profile
 
-- name: Fetch Piecewise
-  git:
-    repo: "{{ git_repo }}"
-    dest: "{{ base_path }}/piecewise.git"
-    version: "{{ piecewise_commit }}"
-
 - name: Deploy Piecewise Python code
   copy:
     src: "../piecewise"

--- a/ansible/templates/nginx_development_default.j2
+++ b/ansible/templates/nginx_development_default.j2
@@ -54,7 +54,7 @@ server {
 	location /collector/retrieve {
 		try_files $uri @collector;
 		auth_basic "Custom Data";
-		auth_basic_user_file {{base_path}}/piecewise.git/htpasswd;
+		auth_basic_user_file {{base_path}}/piecewise/htpasswd;
 	}
 
 	location / {
@@ -68,7 +68,7 @@ server {
 
 	location /admin {
 		auth_basic "Custom Data Admin";
-		auth_basic_user_file {{base_path}}/piecewise.git/htpasswd;
+		auth_basic_user_file {{base_path}}/piecewise/htpasswd;
 	}
 
 	# NOTE: replace domains below with vars

--- a/ansible/templates/nginx_production_default.j2
+++ b/ansible/templates/nginx_production_default.j2
@@ -53,7 +53,7 @@ server {
 	location /collector/retrieve {
 		try_files $uri @collector;
 		auth_basic "Custom Data";
-		auth_basic_user_file {{base_path}}/piecewise.git/htpasswd;
+		auth_basic_user_file {{base_path}}/piecewise/htpasswd;
 	}
 
 	location / {
@@ -67,7 +67,7 @@ server {
 
 	location /admin {
 		auth_basic "Custom Data Admin";
-		auth_basic_user_file {{base_path}}/piecewise.git/htpasswd;
+		auth_basic_user_file {{base_path}}/piecewise/htpasswd;
 	}
 
 	# NOTE: replace domains below with vars

--- a/piecewise_web/admin/index.html
+++ b/piecewise_web/admin/index.html
@@ -24,7 +24,8 @@
 		<tr>
 			<th><a id="sort-id" href="/admin/?sort=id&order=asc">ID</a></th>
 			<th><a id="sort-verified" href="/admin/?sort=verified&order=desc">Verified</a></th>
-			<th><a id="sort-location_type" href="/admin/?sort=isp_user&order=desc">User Reported ISP</a></th>
+			<th><a id="sort-location_type" href="/admin/?sort=isp_user&order=desc">User Selected ISP</a></th>
+			<th><a id="sort-location_type" href="/admin/?sort=other_isp&order=desc">User Other Reported ISP</a></th>
 			<th><a id="sort-connection_type" href="/admin/?sort=connection_type&order=desc">Connection Type</a></th>
 			<th><a id="sort-advertised_download" href="/admin/?sort=advertised_download&order=desc">Advertised Download</a></th>
 			<th><a id="sort-advertised_upload" href="/admin/?sort=advertised_upload&order=desc">Advertised Upload</a></th>
@@ -49,6 +50,7 @@ var fields = [
 	'id',
 	'verified',
 	'isp_user',
+	'other_isp',
 	'connection_type',
 	'advertised_download',
 	'advertised_upload',

--- a/piecewise_web/admin/index.html
+++ b/piecewise_web/admin/index.html
@@ -24,8 +24,8 @@
 		<tr>
 			<th><a id="sort-id" href="/admin/?sort=id&order=asc">ID</a></th>
 			<th><a id="sort-verified" href="/admin/?sort=verified&order=desc">Verified</a></th>
-			<th><a id="sort-location_type" href="/admin/?sort=isp_user&order=desc">User Selected ISP</a></th>
-			<th><a id="sort-location_type" href="/admin/?sort=other_isp&order=desc">User Other Reported ISP</a></th>
+			<th><a id="sort-selected_isp" href="/admin/?sort=isp_user&order=desc">User Selected ISP</a></th>
+			<th><a id="sort-other_isp" href="/admin/?sort=other_isp&order=desc">User Other Reported ISP</a></th>
 			<th><a id="sort-connection_type" href="/admin/?sort=connection_type&order=desc">Connection Type</a></th>
 			<th><a id="sort-advertised_download" href="/admin/?sort=advertised_download&order=desc">Advertised Download</a></th>
 			<th><a id="sort-advertised_upload" href="/admin/?sort=advertised_upload&order=desc">Advertised Upload</a></th>


### PR DESCRIPTION
This PR completes issue #130 , removing reference to a remote git clone in the nginx configs and removing the portion of the Ansible playbook that clones Piecewise to remote entirely.

Additionally, this PR removes OTI specific values used in testing, which should now be done via the ansible -e flag to include extra_vars.  

It also changes a bit of default text that is presented post-form/test submission "at the end of the month" replaced with "soon"; and adds the "Other ISP" text entry field to the admin page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opentechinstitute/piecewise/134)
<!-- Reviewable:end -->
