### PR TITLE
css selector typo fix

### DIFF
--- a/piecewise_web/js/mlab.js
+++ b/piecewise_web/js/mlab.js
@@ -691,7 +691,7 @@ $( document ).ready(function() {
 			if ($('div#container-service_at_home').hasClass('displayed')) {
 				$('div#container-service_at_home').removeClass('displayed')
 				$('div#container-service_at_home').addClass('hidden')
-				$('select[name]=service_at_home').val('a_default')
+				$('select[name="service_at_home"]').val('a_default')
 			}
 			if ($('div#container-no_serv_reason').hasClass('displayed')) {
 				$('div#container-no_serv_reason').removeClass('displayed')


### PR DESCRIPTION
Found this little css seletor typo generating errors in the console:



jquery-1.11.3.min.js:2 Uncaught Error: Syntax error, unrecognized expression: select[name]=service_at_home
    at Function.ga.error (jquery-1.11.3.min.js:2)
    at ga.tokenize (jquery-1.11.3.min.js:2)
    at ga.select (jquery-1.11.3.min.js:2)
    at Function.ga [as find] (jquery-1.11.3.min.js:2)
    at m.fn.init.find (jquery-1.11.3.min.js:2)
    at new m.fn.init (jquery-1.11.3.min.js:2)
    at m (jquery-1.11.3.min.js:2)
    at HTMLSelectElement.<anonymous> (mlab.js:694)
    at HTMLSelectElement.dispatch (jquery-1.11.3.min.js:4)
    at HTMLSelectElement.r.handle (jquery-1.11.3.min.js:4)
ga.error	@	jquery-1.11.3.min.js:2
ga.tokenize	@	jquery-1.11.3.min.js:2
ga.select	@	jquery-1.11.3.min.js:2
ga	@	jquery-1.11.3.min.js:2
find	@	jquery-1.11.3.min.js:2
m.fn.init	@	jquery-1.11.3.min.js:2
m	@	jquery-1.11.3.min.js:2
(anonymous)	@	mlab.js:694
dispatch	@	jquery-1.11.3.min.js:4
r.handle	@	jquery-1.11.3.min.js:4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/piecewise/137)
<!-- Reviewable:end -->
