### PR TITLE
Fixes for survey_normal_location_other and survey_application

### DIFF
--- a/backend/piecewise/api/endpoints/submissions.py
+++ b/backend/piecewise/api/endpoints/submissions.py
@@ -18,9 +18,7 @@ router = APIRouter()
 
 @router.get("/", response_model=List[SubmissionUpdate])
 def get(
-    db: Session = Depends(get_database),
-    skip: int = 0,
-    limit: int = 100,
+    db: Session = Depends(get_database), skip: int = 0, limit: int = 100,
 ):
     """
     Retrieve items.
@@ -30,27 +28,29 @@ def get(
 
 
 @router.post("/", response_model=SubmissionUpdate)
-def submit(*,
-           id: float = Form(None),
-           db: Session = Depends(get_database),
-           survey_current_location: str = Form(None),
-           survey_normal_location: str = Form(None),
-           survey_normal_location_other: str = Form(None),
-           survey_location_performance: str = Form(None),
-           survey_applications: str = Form(None),
-           survey_other_software: str = Form(None),
-           survey_isp: str = Form(None),
-           survey_subscribe_download: str = Form(None),
-           survey_subscribe_upload: str = Form(None),
-           survey_bundle: str = Form(None),
-           survey_current_cost: str = Form(None),
-           actual_download: float = Form(None),
-           actual_upload: float = Form(None),
-           min_rtt: float = Form(None),
-           latitude: float = Form(None),
-           longitude: float = Form(None),
-           bigquery_key: str = Form(None)):
-    if id: # if data stored in dom
+def submit(
+    *,
+    id: float = Form(None),
+    db: Session = Depends(get_database),
+    survey_current_location: str = Form(None),
+    survey_normal_location: str = Form(None),
+    survey_normal_location_other: str = Form(None),
+    survey_location_performance: str = Form(None),
+    survey_applications: List[str] = Form(None),
+    survey_other_software: str = Form(None),
+    survey_isp: str = Form(None),
+    survey_subscribe_download: str = Form(None),
+    survey_subscribe_upload: str = Form(None),
+    survey_bundle: str = Form(None),
+    survey_current_cost: str = Form(None),
+    actual_download: float = Form(None),
+    actual_upload: float = Form(None),
+    min_rtt: float = Form(None),
+    latitude: float = Form(None),
+    longitude: float = Form(None),
+    bigquery_key: str = Form(None)
+):
+    if id:  # if data stored in dom
         """
         Update an item.
         """
@@ -61,7 +61,7 @@ def submit(*,
             survey_normal_location=survey_normal_location,
             survey_normal_location_other=survey_normal_location_other,
             survey_location_performance=survey_location_performance,
-            survey_applications=survey_applications,
+            survey_applications=",".join(map(str, survey_applications)),
             survey_other_software=survey_other_software,
             survey_isp=survey_isp,
             survey_subscribe_download=survey_subscribe_download,
@@ -87,7 +87,7 @@ def submit(*,
             survey_normal_location=survey_normal_location,
             survey_normal_location_other=survey_normal_location_other,
             survey_location_performance=survey_location_performance,
-            survey_applications=survey_applications,
+            survey_applications=",".join(map(str, survey_applications)),
             survey_other_software=survey_other_software,
             survey_isp=survey_isp,
             survey_subscribe_download=survey_subscribe_download,
@@ -101,7 +101,6 @@ def submit(*,
             longitude=longitude,
             bigquery_key=bigquery_key,
         )
-
 
         sub = create_submission(db=db, submission=sub_in)
     return sub

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -143,7 +143,7 @@
             <div class="form-field mb-4" id="container-survey_normal_location_other">
               <label for="survey_normal_location_other" class="field-container">If you selected ‘Different location’ in the previous question, where do you normally access the Internet?</label>
               <div class="field-container">
-                <input id="survey_normal_location_other" type="text" name="survey_service_type_other" class="form-control" title="If you selected ‘Different location’ in the previous question, where do you normally access the Internet?" />
+                <input id="survey_normal_location_other" type="text" name="survey_normal_location_other" class="form-control" title="If you selected ‘Different location’ in the previous question, where do you normally access the Internet?" />
               </div>
             </div>
             <div class="form-field mb-4" id="container-survey_location_performance">


### PR DESCRIPTION
This pull request fixes an incorrect `name` property for the `survey_normal_location_other` form field that kept it from submitting correctly, and updates the backend API to accept a `List` of strings for the `survey_applications` field and then turn it into a comma-separated string for storage into the database. Tested on the WFH staging site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/piecewise/156)
<!-- Reviewable:end -->
