### PR TITLE
Add a timeout to getCurrentPosition(), and make sure that we runTests() even if the user declines geo lookup

### DIFF
--- a/frontend/static/js/ndt-server.js
+++ b/frontend/static/js/ndt-server.js
@@ -7,6 +7,9 @@ const background = document.getElementsByClassName('background')[0];
 const step2 = document.getElementById('Step2');
 const welcome = document.getElementById('Welcome');
 
+// Timeout for getting geolocation from browser
+const GEO_TIMEOUT = 5000;
+
 if (!!consentForm) {
   consentForm.addEventListener('submit', checkLocationConsent);
 }
@@ -72,7 +75,7 @@ function checkLocationConsent () {
 
   if (!!useLocation) {
     if ("geolocation" in navigator) {
-      navigator.geolocation.getCurrentPosition(success, error);
+      navigator.geolocation.getCurrentPosition(success, error, { timeout: GEO_TIMEOUT });
     }
   } else { runTests(); }
 }

--- a/frontend/static/js/ndt-server.js
+++ b/frontend/static/js/ndt-server.js
@@ -117,6 +117,7 @@ function success(position) {
 
 function error(error) {
 	document.getElementById('ErrorMessage').innerHTML = 'ERROR(' + error.code + '): ' + error.message;
+	runTests();
 }
 
 function getNdtServer() {


### PR DESCRIPTION
This includes fixes to both add a timeout to the `getCurrentPosition()` call to get the current browser's location, and to make sure that if a timeout or denial happens (triggering the error handler) we then move on to call `runTests()` rather than just hanging there.

Potentially addresses #159

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/piecewise/164)
<!-- Reviewable:end -->
