### PR TITLE
Only use submissions with coordinates for determining the center of the map

### DIFF
--- a/src/frontend/components/dashboard/MapTab/Map.jsx
+++ b/src/frontend/components/dashboard/MapTab/Map.jsx
@@ -44,7 +44,15 @@ export default function Map({
 
     map.on('load', () => {
       if (geojson.features.length > 0) {
-        const centerPoint = center(geojson);
+        const featuresWithCoordinates = geojson.features.filter(d => {
+          const { coordinates } = d.geometry;
+          if (coordinates.includes(null)) return false;
+          return true;
+        });
+        const centerPoint = center({
+          type: 'FeatureCollection',
+          features: featuresWithCoordinates,
+        });
         const centerCoordinates = centerPoint.geometry.coordinates;
         map.setCenter(centerCoordinates);
         map.setZoom(4);

--- a/src/frontend/components/dashboard/MapTab/MapTab.css
+++ b/src/frontend/components/dashboard/MapTab/MapTab.css
@@ -45,7 +45,7 @@
   padding: 1.5rem;
   position: absolute;
   top: 2rem;
-  width: 400px;
+  width: 450px;
   z-index: 20;
 }
 


### PR DESCRIPTION
When submissions don't include coordinates, they get put on "null island" off the coast of Africa. since this is a US based tool, its off-putting to have the map load over a different part of the world.

This changes the center calculation to ignore any submissions without valid coordinates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/piecewise/194)
<!-- Reviewable:end -->
