### PR TITLE
Add MLab data to <InfoPanel /> table view

### DIFF
--- a/src/frontend/components/dashboard/MapTab/InfoPanel.jsx
+++ b/src/frontend/components/dashboard/MapTab/InfoPanel.jsx
@@ -254,6 +254,36 @@ export default function InfoPanel({
         },
       ],
     },
+    {
+      group: 'MLab internet speed information',
+      rows: [
+        {
+          label: 'Total speed tests',
+          data: 'properties.2020_july_dec_total_dl_samples',
+          formatter: formatNumber,
+        },
+        {
+          label: 'Median download speed',
+          data: 'properties.2020_july_dec_median_dl',
+          formatter: formatMbps,
+        },
+        {
+          label: 'Median upload speed',
+          data: 'properties.2020_july_dec_median_ul',
+          formatter: formatMbps,
+        },
+        {
+          label: 'Percent of tests capable of audio chat',
+          data: 'properties.2020_july_dec_percent_over_audio_threshold',
+          formatter: formatPercent,
+        },
+        {
+          label: 'Percent of tests capable of video chat',
+          data: 'properties.2020_july_dec_percent_over_video_threshold',
+          formatter: formatPercent,
+        },
+      ],
+    },
   ];
 
   return (


### PR DESCRIPTION
Represent the MLab data in the tabular view within the `<InfoPanel />` component so that the narrative and table views have information parity.

![Screen Shot 2020-12-01 at 2 44 39 PM](https://user-images.githubusercontent.com/780941/100805609-c9226780-33e3-11eb-943c-5daad38a8187.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/piecewise/204)
<!-- Reviewable:end -->
