### PR TITLE
Use specific directories for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "/dist"
   ],
   "scripts": {
-    "lint": "eslint --ignore-path .gitignore --ext js,jsx --fix ./src",
+    "lint": "eslint --ignore-path .gitignore --ext js,jsx --fix ./src/backend ./src/common ./src/frontend",
     "test": "jest --coverage --forceExit",
     "doc": "jsdoc -d ./dist/doc/ -r ./src/backend ./src/frontend ./src/worker",
     "build:imported-components": "imported-components src/frontend src/frontend/imported.js",

--- a/src/frontend/components/dashboard/MapTab/InfoPanel.jsx
+++ b/src/frontend/components/dashboard/MapTab/InfoPanel.jsx
@@ -254,6 +254,36 @@ export default function InfoPanel({
         },
       ],
     },
+    {
+      group: 'MLab internet speed information',
+      rows: [
+        {
+          label: 'Total speed tests',
+          data: 'properties.2020_july_dec_total_dl_samples',
+          formatter: formatNumber,
+        },
+        {
+          label: 'Median download speed',
+          data: 'properties.2020_july_dec_median_dl',
+          formatter: formatMbps,
+        },
+        {
+          label: 'Median upload speed',
+          data: 'properties.2020_july_dec_median_ul',
+          formatter: formatMbps,
+        },
+        {
+          label: 'Percent of tests capable of audio chat',
+          data: 'properties.2020_july_dec_percent_over_audio_threshold',
+          formatter: formatPercent,
+        },
+        {
+          label: 'Percent of tests capable of video chat',
+          data: 'properties.2020_july_dec_percent_over_video_threshold',
+          formatter: formatPercent,
+        },
+      ],
+    },
   ];
 
   return (


### PR DESCRIPTION
This PR gets more specific about which folders should be checked by eslint, since having other folders inside there will throw errors when building with Docker. I've tested this locally so am merging without review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/piecewise/205)
<!-- Reviewable:end -->
