### PR TITLE
Add ndt7-js dependency and fix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hapi/joi": "^17.1.1",
         "@koa/cors": "2.2.3",
         "@koa/router": "^8.0.6",
+        "@m-lab/ndt7": "^0.0.5",
         "@material-ui/core": "^4.9.10",
         "@material-ui/icons": "^4.9.1",
         "@material-ui/pickers": "^3.2.10",
@@ -2603,6 +2604,40 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@m-lab/ndt7": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@m-lab/ndt7/-/ndt7-0.0.5.tgz",
+      "integrity": "sha512-x7C6wcQgM/lc3t6PdmxVsbYtCvwnyYfi3BawwkbRUrujJ/e6qR6JirJTHZ5FBL/1eXpKsa/3KxmDXT7BXlZN0g==",
+      "dependencies": {
+        "isomorphic-ws": "^4.0.1",
+        "node-fetch": "^2.6.0",
+        "workerjs": "^0.1.1",
+        "ws": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@m-lab/ndt7/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mapbox/geojson-rewind": {
@@ -14684,6 +14719,14 @@
       "dependencies": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/isstream": {
@@ -29777,6 +29820,11 @@
         "microevent.ts": "~0.1.1"
       }
     },
+    "node_modules/workerjs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/workerjs/-/workerjs-0.1.1.tgz",
+      "integrity": "sha1-t5Oe1UQAk3wcHvNbdLN92bvL3eY="
+    },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -32355,6 +32403,25 @@
         "methods": "^1.1.2",
         "path-to-regexp": "1.x",
         "urijs": "^1.19.2"
+      }
+    },
+    "@m-lab/ndt7": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@m-lab/ndt7/-/ndt7-0.0.5.tgz",
+      "integrity": "sha512-x7C6wcQgM/lc3t6PdmxVsbYtCvwnyYfi3BawwkbRUrujJ/e6qR6JirJTHZ5FBL/1eXpKsa/3KxmDXT7BXlZN0g==",
+      "requires": {
+        "isomorphic-ws": "^4.0.1",
+        "node-fetch": "^2.6.0",
+        "workerjs": "^0.1.1",
+        "ws": "^7.3.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "requires": {}
+        }
       }
     },
     "@mapbox/geojson-rewind": {
@@ -42750,6 +42817,12 @@
           }
         }
       }
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
     },
     "isstream": {
       "version": "0.1.2",
@@ -55367,6 +55440,11 @@
       "requires": {
         "microevent.ts": "~0.1.1"
       }
+    },
+    "workerjs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/workerjs/-/workerjs-0.1.1.tgz",
+      "integrity": "sha1-t5Oe1UQAk3wcHvNbdLN92bvL3eY="
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19807,6 +19807,7 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.1.tgz",
       "integrity": "sha512-sjCuOlvGyCJS40R8BscF5vhVlQjNN069NtQ1gSxyK1u9iqvn6tf7O1R4GNowVZfiZUCRt5MmMs1xd+4V/7Yr0g==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@hapi/joi": "^17.1.1",
     "@koa/cors": "2.2.3",
     "@koa/router": "^8.0.6",
+    "@m-lab/ndt7": "^0.0.5",
     "@material-ui/core": "^4.9.10",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/pickers": "^3.2.10",

--- a/src/frontend/assets/js/ndt7-download-worker.js
+++ b/src/frontend/assets/js/ndt7-download-worker.js
@@ -1,4 +1,4 @@
-/* eslint-env browser, node, worker */
+/* eslint-disable */
 
 // Node doesn't have WebSocket defined, so it needs this library.
 if (typeof WebSocket === 'undefined') {

--- a/src/frontend/assets/js/ndt7-upload-worker.js
+++ b/src/frontend/assets/js/ndt7-upload-worker.js
@@ -1,4 +1,4 @@
-/* eslint-env es6, browser, node, worker */
+/* eslint-disable */
 
 // Node doesn't have WebSocket defined, so it needs this library.
 if (typeof WebSocket === 'undefined') {

--- a/src/frontend/assets/js/ndt7.js
+++ b/src/frontend/assets/js/ndt7.js
@@ -1,4 +1,4 @@
-/* eslint-env browser, node, worker */
+/* eslint-disable */
 
 // ndt7 contains the core ndt7 client functionality. Please, refer
 // to the ndt7 spec available at the following URL:

--- a/src/frontend/components/utils/NdtWidget.jsx
+++ b/src/frontend/components/utils/NdtWidget.jsx
@@ -138,7 +138,7 @@ export default function NdtWidget(props) {
     ).then((exitcode) => {
       if (exitcode != 0) {
         setText("There was an error during the test. Please try again later.");
-        return
+        return;
       }
 
       setText("Test complete");
@@ -147,6 +147,11 @@ export default function NdtWidget(props) {
         c2sRate: c2sRateKbps,
         s2cRate: s2cRateKbps,
       })
+
+      return;
+    }).catch(() => {
+      setText("There was an error during the test. Please try again later.");
+      return;
     });
   }, []);
 


### PR DESCRIPTION
This PR adds a dependency on @m-lab/ndt7-js to package.json and makes the linter happy.

Even if ndt7-js' files are copied into this repo (to make parcel work as intended when importing web workers), having it in package.json is still needed so that the dependencies for ndt7-js (such as `isomorphic-ws`) are downloaded.

Also, linting for those ndt7-js files has been manually disabled and a catch() block has been added to the call to `ndt7.test`. This allows the Docker build to complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/piecewise/219)
<!-- Reviewable:end -->
